### PR TITLE
Specify provider dependency

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -11,5 +11,4 @@ terraform {
 # Configure the Hetzner Cloud Provider
 provider "hcloud" {
   token   = var.hcloud_token
-  version = "~> 1.19"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,13 @@
+# needed for terraform >= 0.13
+terraform {
+  required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+      version = "1.25.2"
+    }
+  }
+}
+
 # Configure the Hetzner Cloud Provider
 provider "hcloud" {
   token   = var.hcloud_token


### PR DESCRIPTION
Terraform `>= 0.13` requires defining provider dependency.